### PR TITLE
Pass username to deny function

### DIFF
--- a/src/Basic.php
+++ b/src/Basic.php
@@ -96,7 +96,7 @@ class Basic
             header('HTTP/1.0 401 Unauthorized');
 
             if ($this->deny) {
-                call_user_func($this->deny);
+                call_user_func($this->deny, $user);
             }
 
             exit;


### PR DESCRIPTION
This lets you reliably include the username in (for example) logging
output.
